### PR TITLE
Added `aria-label` to `alert` directive template

### DIFF
--- a/template/alert/alert.html
+++ b/template/alert/alert.html
@@ -1,4 +1,4 @@
 <div class='alert-box' ng-class='(type || "")'>
   <span ng-transclude></span>
-  <a ng-show='closeable' class='close' ng-click='close()'>&times;</a>
+  <a ng-show='closeable' class='close' aria-label='Close alert' ng-click='close()'>&times;</a>
 </div>


### PR DESCRIPTION
We're using `angular-foundation` in our project and we noticed the "x" in an alert is read out as "times" by screen readers.

This PR adds an `aria-label` to the `alert` directive template for better accessibility.

